### PR TITLE
Cache docker build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -63,7 +63,7 @@ jobs:
         working-directory: ./rails
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup database
         run: bundle exec rails db:migrate


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to improve the CI/CD process. The key changes involve updating the checkout action version, adding a cache step to optimize Docker builds, and correcting a typo in the workflow trigger paths.

Improvements to the CI/CD workflow:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L7-R7): Corrected a typo in the workflow trigger paths from `path` to `paths`.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R46): Updated the `actions/checkout` action from version 3 to version 4. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R46) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L54-R66)
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R46): Added a step to set up Docker Buildx.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R46): Added a caching step for Docker build cache to improve build times.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R46): Modified Docker build cache configuration to use local cache instead of inline cache.