### PR TITLE
issue/4 CI で rubocop を動かす

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,27 @@ jobs:
           yamllint_comment: true
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rubocop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: |
+          gem install bundler -v 2.5.16
+          bundle install
+
+      - name: Run rubocop with reviewdog
+        uses: reviewdog/action-rubocop@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          skip_install: true
+          use_bundler: true


### PR DESCRIPTION
This pull request introduces a new job to the GitHub Actions workflow for linting Ruby code using RuboCop. The most important change is the addition of the `rubocop` job in the `.github/workflows/lint.yml` file.

Changes to GitHub Actions workflow:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R22-R45): Added a new `rubocop` job to run RuboCop with reviewdog on `ubuntu-latest`, including steps to check out the repository, set up Ruby, install dependencies, and run RuboCop.